### PR TITLE
Add glyph and paradox gateways

### DIFF
--- a/gen2-visual/chaos-gateway.html
+++ b/gen2-visual/chaos-gateway.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Chaos Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #gate{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="gate"></pre>
+<script>
+const W=60, H=30;
+const gate=document.getElementById('gate');
+const φ=(1+Math.sqrt(5))/2;
+let frame=0;
+const field=new Float32Array(W*H).fill(0.5);
+function logistic(x,r){return r*x*(1-x);}
+const glyphs=[' ','·',':','*','✶','✷','✸','✹','✺','✵','✴'];
+function evolve(){
+  for(let i=0;i<field.length;i++){
+    const r=3.8+0.2*Math.sin(frame*0.02+i/W*0.3);
+    field[i]=logistic(field[i],r);
+  }
+}
+function render(){
+  evolve();
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const i=y*W+x;
+      const v=field[i];
+      const hue=(x*y+frame*3)%360;
+      const light=40+40*v;
+      const idx=Math.floor(v*(glyphs.length-1));
+      out+=`<span style="color:hsl(${hue},70%,${light}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  gate.innerHTML=out;
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/fractal-gateway.html
+++ b/gen2-visual/fractal-gateway.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Fractal Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #grid{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="grid"></pre>
+<script>
+const W=70,H=35;
+const φ=(1+Math.sqrt(5))/2;
+let t=0;
+const grid=document.getElementById('grid');
+function logistic(x,r){return r*x*(1-x);}
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx=(x-W/2)/W;
+      const dy=(y-H/2)/H;
+      let v=Math.sin(φ*dx*3-t*0.02)+Math.cos(φ*dy*3+t*0.015);
+      v=(v+2)/4;
+      v=logistic(v,3.5+Math.sin(t*0.01));
+      const hue=(x*y+t)%360;
+      const glyphs=[' ','·','*','✷','✹','@'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      out+=`<span style="color:hsl(${hue},70%,${40+40*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  grid.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/glyph-gateway.html
+++ b/gen2-visual/glyph-gateway.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Glyph Gateway</title>
+<style>
+  body {
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #glyphs {
+    font-size:13px;
+    line-height:1;
+    white-space:pre;
+  }
+  span { display:inline-block; width:0.6em; }
+</style>
+</head>
+<body>
+<pre id="glyphs"></pre>
+<script>
+const Φ = (1 + Math.sqrt(5)) / 2;
+const W = 50;
+const H = 30;
+const glyphs = document.getElementById('glyphs');
+const symbols = [' ','.','•','◦','◍','○','◉','◇','◆','⬣','⬢'];
+let frame = 0;
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx = x - W/2;
+      const dy = y - H/2;
+      const r = Math.sqrt(dx*dx + dy*dy);
+      const a = Math.atan2(dy,dx);
+      let v = Math.sin(r*0.2 + frame*0.04) + Math.cos(a*3 + frame*0.02);
+      v += Math.sin((dx+dy)*0.1 + frame*0.03);
+      v = (v + 3)/6;
+      const idx = Math.floor(v * (symbols.length-1));
+      const hue = (r*4 + frame) % 360;
+      out += `<span style="color:hsl(${hue},70%,60%)">${symbols[idx]}</span>`;
+    }
+    out += '\n';
+  }
+  glyphs.innerHTML = out;
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/lattice-gateway.html
+++ b/gen2-visual/lattice-gateway.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Lattice Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #lattice{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="lattice"></pre>
+<script>
+const W=64,H=32;
+const lattice=document.getElementById('lattice');
+let t=0;
+const f=new Float32Array(W*H).fill(0.5);
+function logistic(x,r){return r*x*(1-x);}
+function evolve(){
+  for(let i=0;i<f.length;i++){
+    const r=3.6+0.2*Math.sin(t*0.02+i*0.1);
+    f[i]=logistic(f[i],r);
+  }
+}
+function render(){
+  evolve();
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const i=y*W+x;
+      const v=f[i];
+      const hue=(x*8+y*4+t)%360;
+      const glyphs=[' ','·',':','✧','✦','✶','✷'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      out+=`<span style="color:hsl(${hue},70%,${40+45*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  lattice.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/orbit-gateway.html
+++ b/gen2-visual/orbit-gateway.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Orbit Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #orbit{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="orbit"></pre>
+<script>
+const W=60,H=30;
+let t=0;
+const orbit=document.getElementById('orbit');
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx=x-W/2+0.5*Math.sin(t*0.05);
+      const dy=y-H/2+0.5*Math.cos(t*0.05);
+      const r=Math.sqrt(dx*dx+dy*dy);
+      const a=Math.atan2(dy,dx)+t*0.03;
+      const v=(Math.sin(r*0.25)+Math.cos(a*3)+2)/4;
+      const glyphs=[' ','·','o','*','✶','@'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      const hue=(a*180/Math.PI+t)%360;
+      out+=`<span style="color:hsl(${hue},80%,${40+50*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  orbit.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/paradox-gateway.html
+++ b/gen2-visual/paradox-gateway.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Paradox Gateway</title>
+<style>
+  body {
+    margin:0;
+    background:#000;
+    color:#0ff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #gate {
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span { display:inline-block; width:0.6em; }
+</style>
+</head>
+<body>
+<pre id="gate"></pre>
+<script>
+const φ = (1 + Math.sqrt(5)) / 2;
+const π = Math.PI;
+const W = 60;
+const H = 30;
+const gate = document.getElementById('gate');
+let t = 0;
+function logistic(x,r){ return r*x*(1-x); }
+function render(){
+  let out = '';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx = x - W/2;
+      const dy = y - H/2;
+      const r = Math.sqrt(dx*dx+dy*dy);
+      const a = Math.atan2(dy,dx);
+      let v = Math.sin(r*0.3 - t*0.02) + Math.cos(a*φ + t*0.03);
+      v = (v + 2)/4; // 0..1
+      v = logistic(v, φ);
+      const glyphs = [' ','·','*','◆','◉','@'];
+      const color = `hsl(${(a/π+1)*180},80%,${40+40*v}%)`;
+      const idx = Math.min(glyphs.length-1, Math.floor(v*glyphs.length));
+      out += `<span style="color:${color}">${glyphs[idx]}</span>`;
+    }
+    out += '\n';
+  }
+  gate.innerHTML = out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/pulse-gateway.html
+++ b/gen2-visual/pulse-gateway.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Pulse Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #pulse{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="pulse"></pre>
+<script>
+const W=60,H=30;
+let t=0;
+const pulse=document.getElementById('pulse');
+function logistic(x,r){return r*x*(1-x);}
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx=x-W/2;
+      const dy=y-H/2;
+      const r=Math.sqrt(dx*dx+dy*dy);
+      let v=(Math.sin(r*0.3-t*0.1)+1)/2;
+      v=logistic(v,3.5);
+      const glyphs=[' ','·','*','✦','✹','@'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      const hue=(r*10+t*2)%360;
+      out+=`<span style="color:hsl(${hue},80%,${35+55*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  pulse.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/quantum-gateway.html
+++ b/gen2-visual/quantum-gateway.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Quantum Glyph Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#0ff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #field{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="field"></pre>
+<script>
+const W=64,H=32;
+let f=new Float32Array(W*H).fill(0.5);
+let t=0;
+const field=document.getElementById('field');
+function evolve(){
+  for(let i=0;i<f.length;i++){
+    const r=3.7+0.1*Math.sin(t*0.02+i);
+    f[i]=r*f[i]*(1-f[i]);
+  }
+}
+function render(){
+  evolve();
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const i=y*W+x;
+      const v=f[i];
+      const symbols=[' ','`','·','*','✧','✦','✹'];
+      const idx=Math.floor(v*(symbols.length-1));
+      const hue=(v*360+t*2+x*y)%360;
+      out+=`<span style="color:hsl(${hue},80%,${40+50*v}%)">${symbols[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  field.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/spiral-gateway.html
+++ b/gen2-visual/spiral-gateway.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Spiral Glyph Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #gate{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="gate"></pre>
+<script>
+const W=60,H=30; 
+let frame=0;
+const gate=document.getElementById('gate');
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx=x-W/2;
+      const dy=y-H/2;
+      const r=Math.sqrt(dx*dx+dy*dy);
+      const a=Math.atan2(dy,dx)+frame*0.02;
+      const v=(Math.sin(r*0.3-a)+1)/2;
+      const glyphs=[' ','·','•','✦','✺','✼'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      const hue=(a*180/Math.PI+frame)%360;
+      out+=`<span style="color:hsl(${hue},70%,${35+50*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  gate.innerHTML=out;
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/vortex-gateway.html
+++ b/gen2-visual/vortex-gateway.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Vortex Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #vortex{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="vortex"></pre>
+<script>
+const W=60,H=30;
+let frame=0;
+const vortex=document.getElementById('vortex');
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const dx=x-W/2;
+      const dy=y-H/2;
+      const r=Math.sqrt(dx*dx+dy*dy);
+      const a=Math.atan2(dy,dx)-frame*0.04;
+      const v=(Math.sin(r*0.3-a)+1)/2;
+      const glyphs=[' ','·','•','✶','✷','✹','@'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      const hue=(a*180/Math.PI+frame*2)%360;
+      out+=`<span style="color:hsl(${hue},70%,${35+50*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  vortex.innerHTML=out;
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/gen2-visual/wave-gateway.html
+++ b/gen2-visual/wave-gateway.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Wave Gateway</title>
+<style>
+  body{
+    margin:0;
+    background:#000;
+    color:#fff;
+    font-family:monospace;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+  }
+  #wave{
+    font-size:12px;
+    line-height:1;
+    white-space:pre;
+  }
+  span{display:inline-block;width:0.6em;}
+</style>
+</head>
+<body>
+<pre id="wave"></pre>
+<script>
+const W=64,H=32;
+let t=0;
+const wave=document.getElementById('wave');
+function render(){
+  let out='';
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const v=(Math.sin((x+t)*0.15)+Math.cos((y-t)*0.1)+2)/4;
+      const glyphs=[' ','`','·','~','*','✷','@'];
+      const idx=Math.floor(v*(glyphs.length-1));
+      const hue=(x*5+y*3+t)%360;
+      out+=`<span style="color:hsl(${hue},70%,${40+45*v}%)">${glyphs[idx]}</span>`;
+    }
+    out+='\n';
+  }
+  wave.innerHTML=out;
+  t++;
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `paradox-gateway.html` using logistic math and symbolic glyphs
- add `glyph-gateway.html` with swirling rune patterns
- add more gateways: lattice, vortex, pulse, wave, orbit

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68401b6f4f20832080635f7d81383e31