### PR TITLE
Improve depth and energy visualization

### DIFF
--- a/gen3/holo-matrix-8d.html
+++ b/gen3/holo-matrix-8d.html
@@ -17,14 +17,7 @@
             line-height: 1.1;
             font-size: 10px;
         }
-        .c0 { color: #110022; }
-        .c1 { color: #330044; }
-        .c2 { color: #550066; }
-        .c3 { color: #770088; }
-        .c4 { color: #9900aa; }
-        .c5 { color: #bb44cc; }
-        .c6 { color: #dd88ee; }
-        .c7 { color: #ffccff; }
+        /* Colors are generated dynamically using HSL for smoother gradients */
     </style>
 </head>
 <body>
@@ -72,12 +65,17 @@
                     const d6 = Math.cos(Math.atan2(dy, dx) * 3 + t * 0.02);
                     const d7 = Math.sin(dx * 0.07 + dy * 0.07 + t * 0.03);
                     const d8 = Math.cos(dx * 0.09 - dy * 0.09 - t * 0.04);
+                    const fold = Math.cos(Math.sqrt(dx*dx + dy*dy) * 0.05 - t * 0.02);
 
-                    let val = (d1+d2+d3+d4+d5+d6+d7+d8) / 16 + 0.5;
+                    let val = (d1+d2+d3+d4+d5+d6+d7+d8 + fold) / 18 + 0.5;
                     val = Math.max(0, Math.min(1, val));
                     const idx = Math.floor(val * (symbols.length - 1));
-                    const colorIdx = Math.floor(val * 7.999);
-                    out += `<span class="c${colorIdx}">${symbols[idx]}</span>`;
+
+                    const hue = (val * 360 + t * 0.2) % 360;
+                    const lightness = 40 + 20 * fold;
+                    const color = `hsl(${hue}, 100%, ${lightness}%)`;
+
+                    out += `<span style="color:${color}">${symbols[idx]}</span>`;
                 }
                 out += '\n';
             }


### PR DESCRIPTION
## Summary
- generate HSL colors dynamically in `holo-matrix-8d.html`
- adjust rendering math to include a folding term

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684040b138508320adbb16db0ba1700a