### PR TITLE
Add common viewport and close handling

### DIFF
--- a/gen2-visual/chaos-gateway.html
+++ b/gen2-visual/chaos-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Chaos Gateway</title>
 <style>
   body{
@@ -58,6 +59,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/fractal-gateway.html
+++ b/gen2-visual/fractal-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Fractal Gateway</title>
 <style>
   body{
@@ -52,6 +53,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/gateway.html
+++ b/gen2-visual/gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>ASCII Gateway</title>
 <style>
 body{margin:0;background:#000;color:#fff;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;overflow:hidden}
@@ -45,6 +46,11 @@ function render(t){
   requestAnimationFrame(render);
 }
 render(0);
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/gateway2.html
+++ b/gen2-visual/gateway2.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Holographic Grid Gateway</title>
     <style>
         body {
@@ -147,6 +148,11 @@
     }
     render();
 })();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/glyph-gateway.html
+++ b/gen2-visual/glyph-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Glyph Gateway</title>
 <style>
   body {
@@ -54,6 +55,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/lattice-gateway.html
+++ b/gen2-visual/lattice-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Lattice Gateway</title>
 <style>
   body{
@@ -56,6 +57,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/orbit-gateway.html
+++ b/gen2-visual/orbit-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Orbit Gateway</title>
 <style>
   body{
@@ -50,6 +51,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/paradox-gateway.html
+++ b/gen2-visual/paradox-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Paradox Gateway</title>
 <style>
   body {
@@ -56,6 +57,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/pulse-gateway.html
+++ b/gen2-visual/pulse-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Pulse Gateway</title>
 <style>
   body{
@@ -51,6 +52,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/quantum-gateway.html
+++ b/gen2-visual/quantum-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Quantum Glyph Gateway</title>
 <style>
   body{
@@ -55,6 +56,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/spiral-gateway.html
+++ b/gen2-visual/spiral-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Spiral Glyph Gateway</title>
 <style>
   body{
@@ -50,6 +51,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/temporal-crystals.html
+++ b/gen2-visual/temporal-crystals.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>temporal crystals</title>
@@ -252,6 +252,11 @@
             updateDimensions();
             evolve();
         }, 50);
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
     </script>
 </body>
 </html>

--- a/gen2-visual/unspoken-nano.html
+++ b/gen2-visual/unspoken-nano.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><head><meta charset="UTF-8"><title>∞◆○●◇△</title><meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no,viewport-fit=cover"><style>
+<html lang="en"><head><meta charset="UTF-8"><title>∞◆○●◇△</title><meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no,viewport-fit=cover"><style>
 *{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent;user-select:none}
 body{background:#000;color:#fff;overflow:hidden;font-family:'Courier New',monospace;height:100vh;width:100vw;position:fixed;display:grid;grid-template-rows:1fr auto}
 #∞{font-size:clamp(3px,1.8vmin,10px);line-height:1;white-space:pre;overflow:hidden;background:#000;display:flex;align-items:center;justify-content:center;position:relative}
@@ -225,4 +225,4 @@ function frm(){ren();requestAnimationFrame(frm);}
 console.log("∞");
 console.log("◆");
 rsz();frm();
-</script></body></html>
+document.addEventListener("keydown",e=>{if(e.key=="Escape"&&window.parent!==window)window.parent.postMessage("close","*");});</script></body></html>

--- a/gen2-visual/vortex-gateway.html
+++ b/gen2-visual/vortex-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Vortex Gateway</title>
 <style>
   body{
@@ -50,6 +51,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2-visual/wave-gateway.html
+++ b/gen2-visual/wave-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Wave Gateway</title>
 <style>
   body{
@@ -46,6 +47,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+document.addEventListener('keydown', e=>{
+  if(e.key==='Escape' && window.parent!==window){
+    window.parent.postMessage('close','*');
+  }
+});
 </script>
 </body>
 </html>

--- a/gen2/ant-colony.html
+++ b/gen2/ant-colony.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Ant Colony</title>
     <style>
         body {

--- a/gen2/aurora-symphony.html
+++ b/gen2/aurora-symphony.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Aurora Symphony</title>
     <style>
         body {

--- a/gen2/chaos-attractor.html
+++ b/gen2/chaos-attractor.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Chaos Attractor</title>
     <style>
         body {

--- a/gen2/cosmic-ripples.html
+++ b/gen2/cosmic-ripples.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Cosmic Ripples</title>
     <style>
         body {

--- a/gen2/digital-rain.html
+++ b/gen2/digital-rain.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Digital Rain</title>
     <style>
         body {

--- a/gen2/echo-gateway.html
+++ b/gen2/echo-gateway.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Echo Gateway</title>
 <style>
   body{
@@ -50,6 +51,11 @@ function render(){
   requestAnimationFrame(render);
 }
 render();
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape' && window.parent !== window) {
+                window.parent.postMessage('close', '*');
+            }
+        });
 </script>
 </body>
 </html>

--- a/gen2/fireworks-festival.html
+++ b/gen2/fireworks-festival.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Fireworks Festival</title>
     <style>
         body {

--- a/gen2/fireworks.html
+++ b/gen2/fireworks.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Fireworks</title>
     <style>
         body {

--- a/gen2/flocking-drones.html
+++ b/gen2/flocking-drones.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Flocking Drones</title>
     <style>
         body {

--- a/gen2/garden-bloom.html
+++ b/gen2/garden-bloom.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Garden Bloom</title>
     <style>
         body {

--- a/gen2/glyph-surge.html
+++ b/gen2/glyph-surge.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Glyph Surge</title>
     <style>
         body {

--- a/gen2/holo-matrix-8d.html
+++ b/gen2/holo-matrix-8d.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>8D Holographic Matrix</title>
     <style>
         body {

--- a/gen2/lava-lamp.html
+++ b/gen2/lava-lamp.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Lava Lamp</title>
     <style>
         body {

--- a/gen2/nebula-drift.html
+++ b/gen2/nebula-drift.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Nebula Drift</title>
     <style>
         body {

--- a/gen2/plasma-pulse.html
+++ b/gen2/plasma-pulse.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Plasma Pulse</title>
     <style>
         body {

--- a/gen2/spiral-galaxy.html
+++ b/gen2/spiral-galaxy.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Spiral Galaxy</title>
     <style>
         body {

--- a/gen2/stellar-surge.html
+++ b/gen2/stellar-surge.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Stellar Surge</title>
     <style>
         body {

--- a/gen2/swarming-seeds.html
+++ b/gen2/swarming-seeds.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Swarming Seeds</title>
     <style>
         body {

--- a/gen3/aether-stream.html
+++ b/gen3/aether-stream.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Aether Stream</title>
     <style>
         body {

--- a/gen3/chrono-flux.html
+++ b/gen3/chrono-flux.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Chrono Flux</title>
     <style>
         body {

--- a/gen3/cosmic-lattice.html
+++ b/gen3/cosmic-lattice.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Cosmic Lattice</title>
     <style>
         body {

--- a/gen3/holo-matrix-8d.html
+++ b/gen3/holo-matrix-8d.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>8D Holographic Matrix</title>
     <style>
         body {

--- a/gen3/hyper-cube.html
+++ b/gen3/hyper-cube.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Hyper Cube</title>
     <style>
         body {

--- a/gen3/photon-grid.html
+++ b/gen3/photon-grid.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Photon Grid</title>
     <style>
         body {

--- a/gen3/quantum-foam.html
+++ b/gen3/quantum-foam.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Quantum Foam</title>
     <style>
         body {

--- a/gen3/terra-wave.html
+++ b/gen3/terra-wave.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Terra Wave</title>
     <style>
         body {

--- a/gen3/vortex-fractal.html
+++ b/gen3/vortex-fractal.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Vortex Fractal</title>
     <style>
         body {


### PR DESCRIPTION
## Summary
- add mobile viewport meta tag across gen2, gen3 and gen2-visual pages
- ensure every page can be closed with ESC when embedded
- set missing `lang="en"` attributes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404fda0ff083208375b5be2351568f