### PR TITLE
Remove redundant initialization handlers

### DIFF
--- a/_main/visualizations/spiral-gateway.html
+++ b/_main/visualizations/spiral-gateway.html
@@ -191,10 +191,6 @@
         // Start animation
         render();
         
-        // Resize handler
-        window.addEventListener('resize', () => {
-            location.reload();
-        });
     </script>
 </body>
 </html>

--- a/_main/visualizations/synthesis.html
+++ b/_main/visualizations/synthesis.html
@@ -401,7 +401,6 @@
         }
         
         // start: size then run
-        document.addEventListener('DOMContentLoaded', initialize);
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', initialize);
         } else {

--- a/_main/visualizations/temporal-resonance.html
+++ b/_main/visualizations/temporal-resonance.html
@@ -295,15 +295,11 @@
         }
         
         // Initialize with dynamic sizing and ensure proper startup
-        document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(initialize, 50);
-        });
-        
-        // Fallback initialization in case DOMContentLoaded already fired
         if (document.readyState === 'loading') {
-            // DOM is still loading
+            document.addEventListener('DOMContentLoaded', () => {
+                setTimeout(initialize, 50);
+            });
         } else {
-            // DOM is already loaded
             setTimeout(initialize, 50);
         }
     </script>


### PR DESCRIPTION
## Summary
- clean up duplicate DOMContentLoaded listeners in **synthesis.html** and **temporal-resonance.html**
- drop unnecessary resize reload in **spiral-gateway.html**

No tests were run because none are defined.

------
https://chatgpt.com/codex/tasks/task_e_6841401a3aac8320914d0a1309c6cd3e