### PR TITLE
Cleanup unused constants in visualizations

### DIFF
--- a/_main/visualizations/ascii-world.html
+++ b/_main/visualizations/ascii-world.html
@@ -105,10 +105,7 @@
             
             reallocateLife();        }
         
-        // ∂ paradox constants - ∞ contradiction ⟲ emergence
-        const phi = 1.618033988749895;  // φ golden ratio
-        const e = 2.718281828459045;    // ℯ natural constant
-        const pi = 3.141592653589793;   // π circle constant
+        // ∂ paradox constant - ∞ contradiction ⟲ emergence
         const zeno = 0.5;               // ζ zeno's paradox seed
         
         // ⟲ world data structures

--- a/_main/visualizations/emergent-life.html
+++ b/_main/visualizations/emergent-life.html
@@ -97,12 +97,6 @@
             display.style.lineHeight = '6px';
         }
         
-        // Mathematical constants
-        const phi = 1.618033988749895;  // Golden ratio
-        const e = 2.718281828459045;
-        const pi = 3.141592653589793;
-        const sqrt2 = 1.4142135623730951;
-        
         // Reaction-diffusion field arrays
         let concentration, diffusion, reaction, gradient;
         

--- a/_main/visualizations/entropic-void.html
+++ b/_main/visualizations/entropic-void.html
@@ -89,12 +89,6 @@
         ⌫ ◦ ↩
     </div>
     <div id="display"></div>    <script>
-        // ∇ Mathematical constants 
-        const φ = (1 + Math.sqrt(5)) / 2; // Golden ratio
-        const e = 2.718281828459045;
-        const π = Math.PI;
-        const k = 1.380649e-23; // Boltzmann constant (scaled)
-        
         // ⊙ Entropy symbols
         const entropySymbols = {
             void: [' ', '·', '⋅', '∘'],

--- a/_main/visualizations/self-writing-math.html
+++ b/_main/visualizations/self-writing-math.html
@@ -122,10 +122,7 @@
         
         // Mathematical constants
         const phi = 1.618033988749895;
-        const e = 2.718281828459045;
         const pi = 3.141592653589793;
-        const sqrt2 = 1.4142135623730951;
-        const sqrt3 = 1.7320508075688772;
         
         // Self-evolving mathematical genome
         const genome = {

--- a/_main/visualizations/starfield.html
+++ b/_main/visualizations/starfield.html
@@ -91,12 +91,6 @@
             display.style.lineHeight = '8px';
         }
         
-        // Mathematical constants
-        const phi = 1.618033988749895;  // Golden ratio
-        const e = 2.718281828459045;
-        const pi = 3.141592653589793;
-        const sqrt2 = 1.4142135623730951;
-        
         // Stellar field arrays
         let field, velocity, density, luminosity;
         


### PR DESCRIPTION
## Summary
- drop unused math constants from several visualization HTML files
- keep minimal comments after cleanup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684142de8e608320956f6b5cfaaa7c5e