### PR TITLE
Improve starfield brightness accuracy

### DIFF
--- a/_main/visualizations/starfield.html
+++ b/_main/visualizations/starfield.html
@@ -178,8 +178,10 @@
                     // Luminosity with distance falloff and twinkling
                     const twinkle = Math.sin(t * 5 + x * 0.1 + y * 0.07) * 0.2 + 0.8;
                     const distanceFactor = Math.exp(-stellar.r * 0.6);
-                    const baseLum = Math.pow(density[idx], 1.3);
-                    luminosity[idx] = baseLum * twinkle * distanceFactor;
+                    // Logistic curve maps density → perceived brightness
+                    const baseLum = 1 / (1 + Math.exp(-8 * (density[idx] - 0.5)));
+                    luminosity[idx] = Math.min(1, Math.max(0,
+                        baseLum * twinkle * distanceFactor));
                 }
             }
         }
@@ -197,14 +199,14 @@
                         // Bright stars - complex symbols
                         const symbolIdx = Math.floor(intensity * starCount * 0.8) +
                                         Math.floor(starCount * 0.2);
-                        const colorIdx = Math.floor((intensity + motion * 0.5) * colorCount);
+                        const colorIdx = Math.floor((intensity * 0.7 + motion * 0.3) * colorCount);
                         const symbol = starSymbols[Math.min(symbolIdx, starCount - 1)];
                         const colorClass = colorClasses[Math.min(Math.max(0, colorIdx), colorCount - 1)];
                         output += `<span class="${colorClass}">${symbol}</span>`;
                     } else if (intensity > 0.4) {
                         // Medium stars
                         const symbolIdx = Math.floor(intensity * starCount * 0.5);
-                        const colorIdx = Math.floor(intensity * colorCount * 0.7);
+                        const colorIdx = Math.floor(intensity * colorCount * 0.6);
                         const symbol = starSymbols[Math.min(symbolIdx, starCount - 1)];
                         const colorClass = colorClasses[Math.min(Math.max(0, colorIdx), colorCount - 1)];
                         output += `<span class="${colorClass}">${symbol}</span>`;


### PR DESCRIPTION
## Summary
- refine starfield brightness calculation using a logistic curve
- tune color selection weights for smoother transitions

## Testing
- No tests defined for this project


------
https://chatgpt.com/codex/tasks/task_e_684146be17408320a550c86043085252