### PR TITLE
Small performance tweaks

### DIFF
--- a/_main/index.html
+++ b/_main/index.html
@@ -519,13 +519,13 @@
                 }
             };
             
-            document.addEventListener('click', failsafeHandler, { capture: true });
-            document.addEventListener('touchstart', failsafeHandler, { capture: true });
+            document.addEventListener('click', failsafeHandler, { capture: true, passive: true });
+            document.addEventListener('touchstart', failsafeHandler, { capture: true, passive: true });
             document.addEventListener('keydown', failsafeHandler, { capture: true });
             
             exitListeners.push(() => {
-                document.removeEventListener('click', failsafeHandler, { capture: true });
-                document.removeEventListener('touchstart', failsafeHandler, { capture: true });
+                document.removeEventListener('click', failsafeHandler, { capture: true, passive: true });
+                document.removeEventListener('touchstart', failsafeHandler, { capture: true, passive: true });
                 document.removeEventListener('keydown', failsafeHandler, { capture: true });
             });
             

--- a/_main/visualizations/cellular-consciousness.html
+++ b/_main/visualizations/cellular-consciousness.html
@@ -126,18 +126,17 @@
             100% { text-shadow: 0 0 10px var(--cosmos-coral-bright), 0 0 15px var(--cosmos-coral), 0 0 20px var(--cosmos-coral-bright); }
         }</style>
 </head>
-<body>    <div id="grid"></div><script>        // Dynamic viewport sizing - proper character measurement        let W, H;
+<body>    <div id="grid"></div><script>
+        const grid = document.getElementById('grid');
+        // Dynamic viewport sizing - proper character measurement        let W, H;
         let charWidth, charHeight;
         let dimensionsInitialized = false; // Flag to prevent redundant updates
         
         function updateDimensions(force = false) {            if (dimensionsInitialized && !force) {
-                console.log('◆ Dimensions already initialized, skipping');
                 return;
             }
             
             const stack = new Error().stack;
-            console.log(`◆ updateDimensions called from:`, stack.split('\n')[1]);
-            console.log(`◆ updateDimensions called, initialized: ${dimensionsInitialized}, force: ${force}`);
             const viewportWidth = window.innerWidth;
             const viewportHeight = window.innerHeight;            // Account for zero margin - use full viewport
             const availableWidth = viewportWidth;
@@ -191,7 +190,6 @@
               // Update actual character dimensions - use line height for vertical spacing
             charWidth = actualCharWidth;
             charHeight = lineHeight; // Use line height instead of measured height for accurate spacing// Update grid element styling for maximum viewport coverage
-            const grid = document.getElementById('grid');
             if (grid) {
                 grid.style.fontSize = finalFontSize + 'px';
                 grid.style.lineHeight = lineHeight + 'px';
@@ -223,7 +221,6 @@
             grid.style.transform = 'none';
             grid.style.overflow = 'visible'; // Allow text effects to extend beyond
             
-            console.log(`◆ Grid: ${W}×${H} | Viewport: ${viewportWidth}×${viewportHeight} | Available: ${availableWidth}×${availableHeight} | Font: ${finalFontSize.toFixed(1)}px | LineHeight: ${lineHeight.toFixed(1)}px | Char: ${charWidth.toFixed(2)}×${charHeight.toFixed(2)} | Expected Coverage: ${(H * lineHeight).toFixed(0)}px of ${availableHeight}px`);        
             dimensionsInitialized = true; // Mark as initialized
         }
 
@@ -728,7 +725,7 @@
                 output += '\n';
             }
             
-            document.getElementById('grid').innerHTML = output;
+            grid.innerHTML = output;
             t++;
         }        function seedRandom() {
             // Reduce density significantly for less visual noise
@@ -887,15 +884,11 @@
         let initializationComplete = false;
         function initializeEverything() {
             if (initializationComplete) {
-                console.log('◆ Initialization already complete, skipping');
                 return;
             }
             
-            console.log('◆ Initializing everything...');
             updateDimensions();
-            console.log(`◆ After updateDimensions: ${W}×${H}`);
             initializeSimulation();
-            console.log('◆ Simulation initialized, starting evolution');
               // Add some classic Game of Life patterns after initialization
             setTimeout(() => {
                 // R-pentomino at a random location
@@ -913,7 +906,6 @@
                         }
                     }
                 }
-                console.log('◆ R-pentomino pattern added');
             }, 1000);
             
             evolve();
@@ -969,10 +961,8 @@
             }        }, 12000); // Less frequent        // Handle window resize with proper debouncing and state preservation
         let resizeTimeout;
         window.addEventListener('resize', () => {
-            console.log(`◆ Resize event triggered - dimensions: ${window.innerWidth}×${window.innerHeight}`);
             clearTimeout(resizeTimeout);
             resizeTimeout = setTimeout(() => {
-                console.log(`◆ Resize handler executing after debounce`);
                 const oldW = W, oldH = H;
                 
                 // Always force dimension update on resize
@@ -980,7 +970,6 @@
 
                 // Only reinitialize if dimensions changed significantly
                 if (Math.abs(W - oldW) > 3 || Math.abs(H - oldH) > 3) {
-                    console.log(`◆ Resizing from ${oldW}×${oldH} to ${W}×${H} - reinitializing simulation`);
                     
                     // Preserve center area when resizing
                     const centerPreservationRadius = Math.min(Math.floor(oldW / 4), Math.floor(oldH / 4));
@@ -1032,7 +1021,6 @@
                         }
                     });                
                 } else {
-                    console.log(`◆ Minor resize, dimensions unchanged (${W}×${H})`);
                 }
             }, 150);
         });

--- a/_main/visualizations/quantum-swirl.html
+++ b/_main/visualizations/quantum-swirl.html
@@ -71,6 +71,8 @@
     </div>
     <div id="canvas"></div>
     <script>
+        const canvas = document.getElementById('canvas');
+        const timeDisplay = document.getElementById('timeDisplay');
         let W, H;
         let charWidth, charHeight;
         let t = 0;
@@ -81,7 +83,7 @@
             test.style.visibility = 'hidden';
             test.style.whiteSpace = 'pre';
             test.style.fontFamily = 'Courier New, monospace';
-            test.style.fontSize = getComputedStyle(document.getElementById('canvas')).fontSize;
+            test.style.fontSize = getComputedStyle(canvas).fontSize;
             test.style.lineHeight = '1.1';
             test.textContent = '0'.repeat(10) + '\n'.repeat(10);
             document.body.appendChild(test);
@@ -121,8 +123,8 @@
                 }
                 out += '\n';
             }
-            document.getElementById('canvas').innerHTML = out;
-            document.getElementById('timeDisplay').textContent = t.toFixed(0);
+            canvas.innerHTML = out;
+            timeDisplay.textContent = t.toFixed(0);
             t += dt;
             requestAnimationFrame(render);
         }

--- a/_main/visualizations/self-writing-math.html
+++ b/_main/visualizations/self-writing-math.html
@@ -68,6 +68,7 @@
         ⌫ ◦ ↩
     </div>
     <div id="canvas"></div>    <script>
+        const canvas = document.getElementById('canvas');
         // Dynamic viewport sizing - responsive to window dimensions
         let W, H;
         let charWidth, charHeight;
@@ -108,7 +109,6 @@
             const optimalFontHeight = viewportHeight / H;
             const fontSize = Math.min(optimalFontWidth * 1.8, optimalFontHeight * 1.2);
             
-            const canvas = document.getElementById('canvas');
             canvas.style.fontSize = fontSize + 'px';
             canvas.style.lineHeight = (fontSize * 1.0) + 'px';
             
@@ -389,7 +389,7 @@
                 if (y < renderH - 1) output += '\n';
             }
             
-            document.getElementById('canvas').innerHTML = output;
+            canvas.innerHTML = output;
             t++;
         }
         

--- a/_main/visualizations/starfield.html
+++ b/_main/visualizations/starfield.html
@@ -111,7 +111,6 @@
             charWidth = fontSize * 0.6;
             charHeight = fontSize;
 
-            console.log(`Grid: ${W}x${H} (${W*H} chars), Font: ${fontSize.toFixed(1)}px, Screen: ${viewportWidth}x${viewportHeight}`);
             
             // Precompute values for performance optimization
             preR = new Float32Array(W * H);


### PR DESCRIPTION
## Summary
- make failsafe listeners passive in `_main/index.html`
- cache canvas and time display in `quantum-swirl.html`
- cache canvas in `self-writing-math.html`
- drop debug logging from `starfield.html`
- cache grid element and remove logs from `cellular-consciousness.html`

No tests were run because none are defined.

------
https://chatgpt.com/codex/tasks/task_e_68415408b5cc8320b76b95a75e175426