### PR TITLE
Improve visualization performance

### DIFF
--- a/_main/index.html
+++ b/_main/index.html
@@ -400,7 +400,7 @@
         <button class="ctrl-btn" onclick="about()">?</button>
     </div>    <div class="fullscreen" id="fs">        <div class="close-x" onclick="close_viz_force();">×</div>
         <div class="exit-overlay" id="exitOverlay"></div>
-        <iframe class="frame" id="frame"></iframe>
+        <iframe class="frame" id="frame" loading="lazy"></iframe>
     </div>
 
     <script>        const vizs = [

--- a/_main/visualizations/ascii-world.html
+++ b/_main/visualizations/ascii-world.html
@@ -71,10 +71,12 @@
         let W, H;
         let charWidth, charHeight;
         let t = 0;
+        const canvasElem = document.getElementById('canvas');
         const MAX_COLS = 160;
         const MAX_ROWS = 80;
         const FPS = 30;
         let lastFrame = 0;
+        let running = true;
         
         // ◊ optimal grid dimensions
         function updateDimensions() {            const viewportWidth = window.innerWidth;
@@ -107,9 +109,8 @@
             const optimalFontHeight = viewportHeight / H;
             const fontSize = Math.min(optimalFontWidth * 1.8, optimalFontHeight * 1.2);
             
-            const canvas = document.getElementById('canvas');
-            canvas.style.fontSize = fontSize + 'px';
-            canvas.style.lineHeight = (fontSize * 1.0) + 'px';
+            canvasElem.style.fontSize = fontSize + 'px';
+            canvasElem.style.lineHeight = (fontSize * 1.0) + 'px';
             
             reallocateLife();        }
         
@@ -289,11 +290,12 @@
                 if (y < renderH - 1) output += '\n';
             }
             
-            document.getElementById('canvas').innerHTML = output;
+            canvasElem.innerHTML = output;
             t++;        }
         
         // ∞ evolution loop
         function evolve(now) {
+            if (!running) return;
             if (now - lastFrame < 1000/FPS) { requestAnimationFrame(evolve); return; }
             lastFrame = now;
             render();
@@ -322,6 +324,11 @@
             if (e.key === 'Escape' && window.parent !== window) {
                 window.parent.postMessage('close', '*');
             }
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            running = !document.hidden;
+            if (running) requestAnimationFrame(evolve);
         });
     </script>
 </body>

--- a/_main/visualizations/emergent-life.html
+++ b/_main/visualizations/emergent-life.html
@@ -66,6 +66,8 @@
         let W, H;
         let charWidth, charHeight;
         let t = 0;
+        const displayElem = document.getElementById('display');
+        let running = true;
         
         function updateDimensions() {
             const viewportWidth = window.innerWidth;
@@ -94,9 +96,8 @@
             W = Math.max(60, W);
             H = Math.max(30, H);
             
-            const display = document.getElementById('display');
-            display.style.fontSize = '6px';
-            display.style.lineHeight = '6px';
+            displayElem.style.fontSize = '6px';
+            displayElem.style.lineHeight = '6px';
         }
         
         // Mathematical constant
@@ -271,10 +272,11 @@
                 output += '\n';
             }
             
-            document.getElementById('display').innerHTML = output;
+            displayElem.innerHTML = output;
         }
         
         function loop() {
+            if (!running) return;
             update();
             render();
             requestAnimationFrame(loop);
@@ -287,6 +289,10 @@
         });
           updateDimensions();
         initializeFields();
+        document.addEventListener('visibilitychange', () => {
+            running = !document.hidden;
+            if (running) requestAnimationFrame(loop);
+        });
         loop();
     </script>
 </body>

--- a/_main/visualizations/entropic-void.html
+++ b/_main/visualizations/entropic-void.html
@@ -89,11 +89,14 @@
         ⌫ ◦ ↩
     </div>
     <div id="display"></div>    <script>
-        // ∇ Mathematical constants 
+        // ∇ Mathematical constants
         const φ = (1 + Math.sqrt(5)) / 2; // Golden ratio
         const e = 2.718281828459045;
         const π = Math.PI;
         const k = 1.380649e-23; // Boltzmann constant (scaled)
+        const displayElem = document.getElementById('display');
+        const timeElem = document.getElementById('timeDisplay');
+        let running = true;
         
         // ⊙ Entropy symbols
         const entropySymbols = {
@@ -150,14 +153,13 @@
             fontSize = Math.max(6, Math.min(18, fontSize));
             
             // Apply calculated styles to display
-            const display = document.getElementById('display');
-            display.style.fontSize = fontSize + 'px';
-            display.style.lineHeight = (fontSize * 1.1) + 'px';
-            display.style.position = 'absolute';
-            display.style.top = '0';
-            display.style.left = '0';
-            display.style.margin = '0';
-            display.style.padding = '0';
+            displayElem.style.fontSize = fontSize + 'px';
+            displayElem.style.lineHeight = (fontSize * 1.1) + 'px';
+            displayElem.style.position = 'absolute';
+            displayElem.style.top = '0';
+            displayElem.style.left = '0';
+            displayElem.style.margin = '0';
+            displayElem.style.padding = '0';
             
             centerX = W / 2;
             centerY = H / 2;
@@ -323,13 +325,14 @@
             
             // Update DOM less frequently for better performance
             if (time % 3 === 0) {
-                document.getElementById('display').innerHTML = output;
+                displayElem.innerHTML = output;
             }
-            document.getElementById('timeDisplay').textContent = `${time} (${W}×${H})`;
+            timeElem.textContent = `${time} (${W}×${H})`;
         }
         
         // ∞ animation loop
         function animate() {
+            if (!running) return;
             try {
                 time++;
                 evolveEntropy();
@@ -377,7 +380,12 @@
                 }
             }
         });
-        
+
+        document.addEventListener('visibilitychange', () => {
+            running = !document.hidden;
+            if (running) requestAnimationFrame(animate);
+        });
+
         updateDimensions();
         if (initialized) {
             animate();

--- a/_main/visualizations/quantum-swirl.html
+++ b/_main/visualizations/quantum-swirl.html
@@ -74,14 +74,17 @@
         let W, H;
         let charWidth, charHeight;
         let t = 0;
+        const canvasElem = document.getElementById('canvas');
+        const timeElem = document.getElementById('timeDisplay');
         const dt = 0.5;
+        let running = true;
         function updateDimensions() {
             const test = document.createElement('div');
             test.style.position = 'absolute';
             test.style.visibility = 'hidden';
             test.style.whiteSpace = 'pre';
             test.style.fontFamily = 'Courier New, monospace';
-            test.style.fontSize = getComputedStyle(document.getElementById('canvas')).fontSize;
+            test.style.fontSize = getComputedStyle(canvasElem).fontSize;
             test.style.lineHeight = '1.1';
             test.textContent = '0'.repeat(10) + '\n'.repeat(10);
             document.body.appendChild(test);
@@ -98,6 +101,7 @@
         const symbols = [' ', '·', ':', '∘', '○', '◦', '◉', '●', '⬢', '⊙'];
         
         function render() {
+            if (!running) return;
             let out = '';
             for (let y = 0; y < H; y++) {
                 for (let x = 0; x < W; x++) {
@@ -121,8 +125,8 @@
                 }
                 out += '\n';
             }
-            document.getElementById('canvas').innerHTML = out;
-            document.getElementById('timeDisplay').textContent = t.toFixed(0);
+            canvasElem.innerHTML = out;
+            timeElem.textContent = t.toFixed(0);
             t += dt;
             requestAnimationFrame(render);
         }
@@ -138,7 +142,12 @@
                 }
             }
         });
-        
+
+        document.addEventListener('visibilitychange', () => {
+            running = !document.hidden;
+            if (running) requestAnimationFrame(render);
+        });
+
         updateDimensions();
         render();
     </script>

--- a/_main/visualizations/starfield.html
+++ b/_main/visualizations/starfield.html
@@ -73,6 +73,7 @@
         const MAX_ROWS = 80;
         const FPS = 30;
         let lastFrame = 0;
+        let running = true;
         
         // Calculate optimal grid size based on viewport
         function updateDimensions() {
@@ -288,6 +289,7 @@
         }
         
         function loop(now) {
+            if (!running) return;
             if (now - lastFrame < 1000/FPS) { requestAnimationFrame(loop); return; }
             lastFrame = now;
             update();
@@ -312,6 +314,11 @@
             if (e.key === 'Escape' && window.parent !== window) {
                 window.parent.postMessage('close', '*');
             }
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            running = !document.hidden;
+            if (running) requestAnimationFrame(loop);
         });
 
         updateDimensions();


### PR DESCRIPTION
## Summary
- lazily load fullscreen iframe
- cache canvas/display nodes in visualizations
- stop heavy loops while tab is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841540bede08320a03a4eea2b9d5be3