### PR TITLE
Performance tweaks in visualizations

### DIFF
--- a/_main/index.html
+++ b/_main/index.html
@@ -426,13 +426,16 @@
         
         let isFullscreenOpen = false;
         let exitListeners = [];
+        let currentViz = '';
 
         function open_viz(file) {
+            if (isFullscreenOpen && currentViz === file) return;
+            currentViz = file;
             frameElem.src = 'visualizations/' + file;
             fsElem.style.display = 'block';
             document.body.style.overflow = 'hidden';
             isFullscreenOpen = true;
-              // Setup multiple exit paths
+            // Setup multiple exit paths
             setupExitMechanisms();
         }
 

--- a/_main/visualizations/ascii-world.html
+++ b/_main/visualizations/ascii-world.html
@@ -71,6 +71,7 @@
         let W, H;
         let charWidth, charHeight;
         let t = 0;
+        const canvasElem = document.getElementById('canvas');
         const MAX_COLS = 160;
         const MAX_ROWS = 80;
         const FPS = 30;
@@ -107,9 +108,8 @@
             const optimalFontHeight = viewportHeight / H;
             const fontSize = Math.min(optimalFontWidth * 1.8, optimalFontHeight * 1.2);
             
-            const canvas = document.getElementById('canvas');
-            canvas.style.fontSize = fontSize + 'px';
-            canvas.style.lineHeight = (fontSize * 1.0) + 'px';
+            canvasElem.style.fontSize = fontSize + 'px';
+            canvasElem.style.lineHeight = (fontSize * 1.0) + 'px';
             
             reallocateLife();        }
         
@@ -289,7 +289,7 @@
                 if (y < renderH - 1) output += '\n';
             }
             
-            document.getElementById('canvas').innerHTML = output;
+            canvasElem.innerHTML = output;
             t++;        }
         
         // ∞ evolution loop

--- a/_main/visualizations/cellular-consciousness.html
+++ b/_main/visualizations/cellular-consciousness.html
@@ -131,13 +131,10 @@
         let dimensionsInitialized = false; // Flag to prevent redundant updates
         
         function updateDimensions(force = false) {            if (dimensionsInitialized && !force) {
-                console.log('◆ Dimensions already initialized, skipping');
+                // console.log removed for performance
                 return;
             }
             
-            const stack = new Error().stack;
-            console.log(`◆ updateDimensions called from:`, stack.split('\n')[1]);
-            console.log(`◆ updateDimensions called, initialized: ${dimensionsInitialized}, force: ${force}`);
             const viewportWidth = window.innerWidth;
             const viewportHeight = window.innerHeight;            // Account for zero margin - use full viewport
             const availableWidth = viewportWidth;
@@ -223,7 +220,7 @@
             grid.style.transform = 'none';
             grid.style.overflow = 'visible'; // Allow text effects to extend beyond
             
-            console.log(`◆ Grid: ${W}×${H} | Viewport: ${viewportWidth}×${viewportHeight} | Available: ${availableWidth}×${availableHeight} | Font: ${finalFontSize.toFixed(1)}px | LineHeight: ${lineHeight.toFixed(1)}px | Char: ${charWidth.toFixed(2)}×${charHeight.toFixed(2)} | Expected Coverage: ${(H * lineHeight).toFixed(0)}px of ${availableHeight}px`);        
+            // log removed for performance
             dimensionsInitialized = true; // Mark as initialized
         }
 
@@ -887,15 +884,11 @@
         let initializationComplete = false;
         function initializeEverything() {
             if (initializationComplete) {
-                console.log('◆ Initialization already complete, skipping');
                 return;
             }
-            
-            console.log('◆ Initializing everything...');
+
             updateDimensions();
-            console.log(`◆ After updateDimensions: ${W}×${H}`);
             initializeSimulation();
-            console.log('◆ Simulation initialized, starting evolution');
               // Add some classic Game of Life patterns after initialization
             setTimeout(() => {
                 // R-pentomino at a random location
@@ -913,7 +906,7 @@
                         }
                     }
                 }
-                console.log('◆ R-pentomino pattern added');
+                // pattern added
             }, 1000);
             
             evolve();
@@ -969,10 +962,8 @@
             }        }, 12000); // Less frequent        // Handle window resize with proper debouncing and state preservation
         let resizeTimeout;
         window.addEventListener('resize', () => {
-            console.log(`◆ Resize event triggered - dimensions: ${window.innerWidth}×${window.innerHeight}`);
             clearTimeout(resizeTimeout);
             resizeTimeout = setTimeout(() => {
-                console.log(`◆ Resize handler executing after debounce`);
                 const oldW = W, oldH = H;
                 
                 // Always force dimension update on resize
@@ -980,7 +971,6 @@
 
                 // Only reinitialize if dimensions changed significantly
                 if (Math.abs(W - oldW) > 3 || Math.abs(H - oldH) > 3) {
-                    console.log(`◆ Resizing from ${oldW}×${oldH} to ${W}×${H} - reinitializing simulation`);
                     
                     // Preserve center area when resizing
                     const centerPreservationRadius = Math.min(Math.floor(oldW / 4), Math.floor(oldH / 4));
@@ -1031,8 +1021,6 @@
                             }
                         }
                     });                
-                } else {
-                    console.log(`◆ Minor resize, dimensions unchanged (${W}×${H})`);
                 }
             }, 150);
         });

--- a/_main/visualizations/emergent-life.html
+++ b/_main/visualizations/emergent-life.html
@@ -66,6 +66,7 @@
         let W, H;
         let charWidth, charHeight;
         let t = 0;
+        const displayElem = document.getElementById('display');
         
         function updateDimensions() {
             const viewportWidth = window.innerWidth;
@@ -94,9 +95,8 @@
             W = Math.max(60, W);
             H = Math.max(30, H);
             
-            const display = document.getElementById('display');
-            display.style.fontSize = '6px';
-            display.style.lineHeight = '6px';
+            displayElem.style.fontSize = '6px';
+            displayElem.style.lineHeight = '6px';
         }
         
         // Mathematical constant
@@ -271,7 +271,7 @@
                 output += '\n';
             }
             
-            document.getElementById('display').innerHTML = output;
+            displayElem.innerHTML = output;
         }
         
         function loop() {

--- a/_main/visualizations/starfield.html
+++ b/_main/visualizations/starfield.html
@@ -111,7 +111,6 @@
             charWidth = fontSize * 0.6;
             charHeight = fontSize;
 
-            console.log(`Grid: ${W}x${H} (${W*H} chars), Font: ${fontSize.toFixed(1)}px, Screen: ${viewportWidth}x${viewportHeight}`);
             
             // Precompute values for performance optimization
             preR = new Float32Array(W * H);


### PR DESCRIPTION
## Summary
- cache DOM elements in `ascii-world.html` and `emergent-life.html`
- drop debug logging from `starfield.html`
- prune excessive logging in `cellular-consciousness.html`
- avoid reloading the same visualization in `index.html`

No tests were run because none are defined.

------
https://chatgpt.com/codex/tasks/task_e_6841540681a083208cfb60b5f257c02c